### PR TITLE
removed repetitive comments

### DIFF
--- a/jhotdraw-api/src/main/java/org/jhotdraw/api/app/MenuBuilder.java
+++ b/jhotdraw-api/src/main/java/org/jhotdraw/api/app/MenuBuilder.java
@@ -55,263 +55,197 @@ public interface MenuBuilder {
   /**
    * Optionally adds one or more "Exit" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the last section of the "File" menu.
-   *
    * <p>Note that OSXApplication does <b>not</b> invoke this method and instead retrieves an action
    * with ID {@code ExitAction.ID} from the action map of the {@code ApplicationModel} and adds it
    * to the "Application" menu.
    *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addExitItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Clear File" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the first section of the "File" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addClearFileItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "New Window" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the first section of the "File" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addNewWindowItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "New File" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the first section of the "File" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addNewFileItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Load file" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the first section of the "File" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addLoadFileItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Open File" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the first section of the "File" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addOpenFileItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Close File" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the second section of the "File" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addCloseFileItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Save File" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the second section of the "File" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addSaveFileItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Export File" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the second section of the "File" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addExportFileItems(JMenu m, Application app, View v);
 
   /**
-   * Optionally adds one or more "Print File" items to a menu.
+   * Optionally adds one or more "Print File" items to a menu.u.
    *
-   * <p>Most applications use this method for adding items to the third section of the "File" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addPrintFileItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more file related items to a menu.
    *
-   * <p>Most applications use this method for adding items to the third section of the "File" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addOtherFileItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Undo" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the first section of the "Edit" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addUndoItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Clipboard" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the second section of the "Edit" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addClipboardItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Selection" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the third section of the "Edit" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addSelectionItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Find" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the fourth section of the "Edit" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addFindItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more editing related items to a menu.
    *
-   * <p>Most applications use this method for adding items to the fifth section of the "Edit" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addOtherEditItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more view related items to a menu.
    *
-   * <p>Most applications use this method for adding items to the first section of the "View" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addOtherViewItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more additional menus to a menu bar or a pop up menu.
    *
-   * <p>Most applications add additional menus between the "View" menu and the "Window" menu to the
-   * menu bar.
-   *
    * @param m A (potentially non-empty) list of menus.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param app
+   * @param v
    */
   void addOtherMenus(List<JMenu> m, Application app, View v);
 
   /**
    * Optionally adds one or more window related items to a menu.
    *
-   * <p>Most applications use this method for adding items to the second section of the "Window"
-   * menu. (The first section usually contains application specific items). Some applications, such
-   * as SDIApplication add these items to the "View" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addOtherWindowItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "Help" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the first section of the "Help" menu.
-   *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addHelpItems(JMenu m, Application app, View v);
 
   /**
    * Optionally adds one or more "About" items to a menu.
    *
-   * <p>Most applications use this method for adding items to the last section of the "Help" menu.
-   *
    * <p>Note that OSXApplication does <b>not</b> invoke this method and instead retrieves an action
    * with ID {@code AboutAction.ID} from the action map of the {@code ApplicationModel} and adds it
    * to the "Application" menu.
    *
-   * @param m A (potentially non-empty) menu.
-   * @param app The Application for which the menu is built.
-   * @param v A view the menu is used exclusively for a specific view, null if the menu is shared by
-   *     all views.
+   * @param m
+   * @param app
+   * @param v
    */
   void addAboutItems(JMenu m, Application app, View v);
 }

--- a/jhotdraw-api/src/main/java/org/jhotdraw/api/app/MenuBuilder.java
+++ b/jhotdraw-api/src/main/java/org/jhotdraw/api/app/MenuBuilder.java
@@ -59,182 +59,182 @@ public interface MenuBuilder {
    * with ID {@code ExitAction.ID} from the action map of the {@code ApplicationModel} and adds it
    * to the "Application" menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addExitItems(JMenu m, Application app, View v);
+  void addExitItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Clear File" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addClearFileItems(JMenu m, Application app, View v);
+  void addClearFileItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "New Window" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addNewWindowItems(JMenu m, Application app, View v);
+  void addNewWindowItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "New File" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addNewFileItems(JMenu m, Application app, View v);
+  void addNewFileItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Load file" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addLoadFileItems(JMenu m, Application app, View v);
+  void addLoadFileItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Open File" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addOpenFileItems(JMenu m, Application app, View v);
+  void addOpenFileItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Close File" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addCloseFileItems(JMenu m, Application app, View v);
+  void addCloseFileItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Save File" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addSaveFileItems(JMenu m, Application app, View v);
+  void addSaveFileItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Export File" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addExportFileItems(JMenu m, Application app, View v);
+  void addExportFileItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Print File" items to a menu.u.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addPrintFileItems(JMenu m, Application app, View v);
+  void addPrintFileItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more file related items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addOtherFileItems(JMenu m, Application app, View v);
+  void addOtherFileItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Undo" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addUndoItems(JMenu m, Application app, View v);
+  void addUndoItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Clipboard" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addClipboardItems(JMenu m, Application app, View v);
+  void addClipboardItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Selection" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addSelectionItems(JMenu m, Application app, View v);
+  void addSelectionItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Find" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addFindItems(JMenu m, Application app, View v);
+  void addFindItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more editing related items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addOtherEditItems(JMenu m, Application app, View v);
+  void addOtherEditItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more view related items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addOtherViewItems(JMenu m, Application app, View v);
+  void addOtherViewItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more additional menus to a menu bar or a pop up menu.
    *
-   * @param m A (potentially non-empty) list of menus.
-   * @param app
-   * @param v
+   * @param menus A (potentially non-empty) list of menus.
+   * @param application
+   * @param viewMenu
    */
-  void addOtherMenus(List<JMenu> m, Application app, View v);
+  void addOtherMenus(List<JMenu> menus, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more window related items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addOtherWindowItems(JMenu m, Application app, View v);
+  void addOtherWindowItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "Help" items to a menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addHelpItems(JMenu m, Application app, View v);
+  void addHelpItems(JMenu menu, Application application, View viewMenu);
 
   /**
    * Optionally adds one or more "About" items to a menu.
@@ -243,9 +243,10 @@ public interface MenuBuilder {
    * with ID {@code AboutAction.ID} from the action map of the {@code ApplicationModel} and adds it
    * to the "Application" menu.
    *
-   * @param m
-   * @param app
-   * @param v
+   * @param menu
+   * @param application
+   * @param viewMenu
    */
-  void addAboutItems(JMenu m, Application app, View v);
+  void addAboutItems(JMenu menu, Application application, View viewMenu);
 }
+


### PR DESCRIPTION
Removed repeated comments that explains the params m , app , v. Only kept the definitions for the first time they are declared.

I also removed the "mostly used" comments for each method and kept what it does , for code clarity.